### PR TITLE
New editor buttons & mobile full screen mode

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -39,7 +39,7 @@
 	</head>
 	<body>
 		<h1>Test Plans Editor Toolbar</h1>
-		<form action>
+		<form>
 			<textarea id="edit_textarea" cols="60" rows="15"
 				spellcheck="false">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam tincidunt lectus mauris, ac elementum nibh rutrum in. Sed porttitor tellus vitae nisi pulvinar congue. Sed hendrerit a sapien in porta. Ut vitae enim et purus blandit lobortis et suscipit quam. Vestibulum cursus feugiat pharetra.
 

--- a/demo.html
+++ b/demo.html
@@ -7,7 +7,7 @@
 		<style>
 			body {
 				max-width: 70ch;
-				width: 90vmax;
+				width: 90vw;
 				margin: 5vmax auto;
 				font-family: system-ui;
 				font-size: 1.1875rem;
@@ -22,6 +22,7 @@
 			}
 
             textarea {
+				max-width: 100%;
                 font: inherit;
             }
 
@@ -47,6 +48,8 @@ https://grinnellplans.com
 Integer a eros tellus. Vivamus pellentesque pellentesque viverra. Phasellus vitae eros elit. Praesent eu convallis turpis.
 
 Pellentesque ac odio mattis, vestibulum massa sed, viverra leo. Nullam sem mi, placerat ac nisl at, porttitor scelerisque tortor. Aenean ut luctus dolor. Mauris velit risus, blandit ac lacus sit amet, vehicula ullamcorper diam. Sed suscipit, ex a imperdiet suscipit, erat nisi fermentum est, non finibus lectus eros eu purus.</textarea>
+			<button type="submit" value="Change Plan" class="submitinput">Change
+				Plan</button>
 		</form>
 		<script src="plans-editor-toolbar.user.js"></script>
 	</body>

--- a/demo.html
+++ b/demo.html
@@ -39,20 +39,18 @@
 	</head>
 	<body>
 		<h1>Test Plans Editor Toolbar</h1>
-		<div id="editbox">
-			<form>
-				<textarea id="edit_textarea" cols="60" rows="15"
-					spellcheck="false">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam tincidunt lectus mauris, ac elementum nibh rutrum in. Sed porttitor tellus vitae nisi pulvinar congue. Sed hendrerit a sapien in porta. Ut vitae enim et purus blandit lobortis et suscipit quam. Vestibulum cursus feugiat pharetra.
+		<form id="editbox">
+			<textarea id="edit_textarea" cols="60" rows="15"
+				spellcheck="false">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam tincidunt lectus mauris, ac elementum nibh rutrum in. Sed porttitor tellus vitae nisi pulvinar congue. Sed hendrerit a sapien in porta. Ut vitae enim et purus blandit lobortis et suscipit quam. Vestibulum cursus feugiat pharetra.
 
 https://grinnellplans.com
 
 Integer a eros tellus. Vivamus pellentesque pellentesque viverra. Phasellus vitae eros elit. Praesent eu convallis turpis.
 
 Pellentesque ac odio mattis, vestibulum massa sed, viverra leo. Nullam sem mi, placerat ac nisl at, porttitor scelerisque tortor. Aenean ut luctus dolor. Mauris velit risus, blandit ac lacus sit amet, vehicula ullamcorper diam. Sed suscipit, ex a imperdiet suscipit, erat nisi fermentum est, non finibus lectus eros eu purus.</textarea>
-				<button type="submit" value="Change Plan" class="submitinput">Change
-					Plan</button>
-			</form>
-		</div>
+			<button type="submit" value="Change Plan" class="submitinput">Change
+				Plan</button>
+		</form>
 		<script src="plans-editor-toolbar.user.js"></script>
 	</body>
 

--- a/demo.html
+++ b/demo.html
@@ -39,18 +39,20 @@
 	</head>
 	<body>
 		<h1>Test Plans Editor Toolbar</h1>
-		<form>
-			<textarea id="edit_textarea" cols="60" rows="15"
-				spellcheck="false">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam tincidunt lectus mauris, ac elementum nibh rutrum in. Sed porttitor tellus vitae nisi pulvinar congue. Sed hendrerit a sapien in porta. Ut vitae enim et purus blandit lobortis et suscipit quam. Vestibulum cursus feugiat pharetra.
+		<div id="editbox">
+			<form>
+				<textarea id="edit_textarea" cols="60" rows="15"
+					spellcheck="false">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam tincidunt lectus mauris, ac elementum nibh rutrum in. Sed porttitor tellus vitae nisi pulvinar congue. Sed hendrerit a sapien in porta. Ut vitae enim et purus blandit lobortis et suscipit quam. Vestibulum cursus feugiat pharetra.
 
 https://grinnellplans.com
 
 Integer a eros tellus. Vivamus pellentesque pellentesque viverra. Phasellus vitae eros elit. Praesent eu convallis turpis.
 
 Pellentesque ac odio mattis, vestibulum massa sed, viverra leo. Nullam sem mi, placerat ac nisl at, porttitor scelerisque tortor. Aenean ut luctus dolor. Mauris velit risus, blandit ac lacus sit amet, vehicula ullamcorper diam. Sed suscipit, ex a imperdiet suscipit, erat nisi fermentum est, non finibus lectus eros eu purus.</textarea>
-			<button type="submit" value="Change Plan" class="submitinput">Change
-				Plan</button>
-		</form>
+				<button type="submit" value="Change Plan" class="submitinput">Change
+					Plan</button>
+			</form>
+		</div>
 		<script src="plans-editor-toolbar.user.js"></script>
 	</body>
 

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -74,7 +74,6 @@ styles.innerHTML = `
         #editbox .submitinput {
             position: absolute;
             left: 50%;
-            inset-block-end: .25rem;
             transform: translateX(-50%);
             z-index: 1000000;
         }

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     	PlansEditorToolbar
 // @description	Adds date, hr, bold, italic, and link buttons to the Plans editor for easier formatting (especially on mobile!)
-// @version  	1.5.0-beta2
+// @version  	1.5.0-beta3
 // @match		https://grinnellplans.com/*
 // @downloadURL https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
 // @updateURL 	https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
@@ -23,6 +23,8 @@ const icons = {
     date: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M15 4h3v14H2V4h3V3c0-.83.67-1.5 1.5-1.5S8 2.17 8 3v1h4V3c0-.83.67-1.5 1.5-1.5S15 2.17 15 3v1zM6 3v2.5c0 .28.22.5.5.5s.5-.22.5-.5V3c0-.28-.22-.5-.5-.5S6 2.72 6 3zm7 0v2.5c0 .28.22.5.5.5s.5-.22.5-.5V3c0-.28-.22-.5-.5-.5s-.5.22-.5.5zm4 14V8H3v9h14zM7 16V9H5v7h2zm4 0V9H9v7h2zm4 0V9h-2v7h2z"/></svg>',
     close: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M15.75 6.75L18 3v14l-2.25-3.75L17 12h-4v4l1.25-1.25L18 17H2l3.75-2.25L7 16v-4H3l1.25 1.25L2 17V3l2.25 3.75L3 8h4V4L5.75 5.25 2 3h16l-3.75 2.25L13 4v4h4z"/></svg>',
     save: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M14.5 2H3.7C2.7 2 2 2.7 2 3.7v12.6c0 1 .7 1.7 1.7 1.7h12.6c1 0 1.7-.7 1.7-1.7V6l-3.5-4zM10 15.6a2.1 2.1 0 1 1 0-4.2 2.1 2.1 0 0 1 0 4.2zm2.7-7.5H4.3V4.2h8.4v4z"/></svg>',
+    planLove:
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M6 14H4V6h2V4H2v12h4M14 4v2h2v8h-2v2h4V4"/></svg>',
 };
 const styles = document.createElement('style');
 styles.innerHTML = `
@@ -72,8 +74,9 @@ styles.innerHTML = `
             margin-inline-end: 0.5rem;
         }
         #editbox .submitinput {
-            position: absolute;
+            position: fixed;
             left: 50%;
+            bottom: 10px;
             transform: translateX(-50%);
             z-index: 1000000;
         }
@@ -94,18 +97,20 @@ function initToolbar() {
     const toolbar = document.createElement('div');
     toolbar.classList.add('plans-editor-toolbar');
 
-    const dateButton = buildaButton('[date]', 'date');
-    const hrButton = buildaButton('Horizontal Rule', 'hr');
     const boldButton = buildaButton('Bold', 'bold');
     const italicButton = buildaButton('Italic', 'italic');
     const linkButton = buildaButton('Link', 'link');
+    const loveButton = buildaButton('Plan Love', 'planLove');
+    const dateButton = buildaButton('[date]', 'date');
+    const hrButton = buildaButton('Horizontal Rule', 'hr');
     const closeButton = buildaButton('Close Editor', 'close');
 
-    toolbar.appendChild(dateButton);
-    toolbar.appendChild(hrButton);
     toolbar.appendChild(boldButton);
     toolbar.appendChild(italicButton);
     toolbar.appendChild(linkButton);
+    toolbar.appendChild(loveButton);
+    toolbar.appendChild(dateButton);
+    toolbar.appendChild(hrButton);
     toolbar.appendChild(closeButton);
 
     submitButton.innerHTML = icons.save + submitButton.innerHTML;
@@ -119,6 +124,7 @@ function initToolbar() {
     boldButton.addEventListener('click', formatBold);
     italicButton.addEventListener('click', formatItalic);
     linkButton.addEventListener('click', insertLink);
+    loveButton.addEventListener('click', insertPlanLove);
     closeButton.addEventListener('click', () => {
         document.body.classList.remove('plans-editor-focused');
         submitButton.focus();
@@ -251,4 +257,9 @@ function formatBold(e) {
 function formatItalic(e) {
     e.preventDefault();
     wrapText('<i>', '</i>');
+}
+
+function insertPlanLove(e) {
+    e.preventDefault();
+    wrapText('[', ']');
 }

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     	PlansEditorToolbar
 // @description	Adds date, hr, bold, italic, and link buttons to the Plans editor for easier formatting (especially on mobile!)
-// @version  	1.5.0-beta
+// @version  	1.5.0-beta2
 // @match		https://grinnellplans.com/*
 // @downloadURL https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
 // @updateURL 	https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -84,9 +84,11 @@ styles.innerHTML = `
 }
 `;
 
-const submitButton = document.querySelector('#editbox .submitinput');
-const textarea = document.getElementsByTagName('textarea')[0];
-if (textarea !== undefined) {
+const editForm = document.getElementById('editbox');
+const submitButton = editForm.querySelector('.submitinput');
+const textarea = editForm.querySelector('textarea');
+
+if (editForm !== null) {
     initToolbar();
 }
 
@@ -148,9 +150,11 @@ function initToolbar() {
                 case 'k':
                     insertLink(e);
                     break;
-                    break;
                 case 'l':
                     insertPlanLove(e);
+                    break;
+                case 's':
+                    editForm.requestSubmit(submitButton);
                     break;
             }
         }

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -39,8 +39,34 @@ styles.innerHTML = `
     width: 18px;
     height: 18px;
 }
+.plans-editor-button--close-editor {
+    display: none !important;
+}
+@media( max-width: 40em ) {
+    .plans-editor-focused {
+        textarea {
+            position: fixed;
+            inset: var(--toolbar-height) 0 0 0;
+            z-index: 999999;
+        }
+        .plans-editor-toolbar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            z-index: 1000000;
+            background: currentColor;
+            padding: .25em;
+        }
+        .plans-editor-button--close-editor {
+            display: block !important;
+            margin-inline-start: auto;
+        }
+    }
+}
 `;
 
+const submitButton = document.querySelector('button.submitinput');
 const textarea = document.getElementsByTagName('textarea')[0];
 if (textarea !== undefined) {
     initToolbar();
@@ -58,12 +84,14 @@ function initToolbar() {
     const boldButton = buildaButton('Bold', 'bold');
     const italicButton = buildaButton('Italic', 'italic');
     const linkButton = buildaButton('Link', 'link');
+    const closeButton = buildaButton('Close Editor', '');
 
     toolbar.appendChild(dateButton);
     toolbar.appendChild(hrButton);
     toolbar.appendChild(boldButton);
     toolbar.appendChild(italicButton);
     toolbar.appendChild(linkButton);
+    toolbar.appendChild(closeButton);
 
     dateButton.addEventListener('click', () => {
         insertText('[date]');
@@ -74,6 +102,13 @@ function initToolbar() {
     boldButton.addEventListener('click', formatBold);
     italicButton.addEventListener('click', formatItalic);
     linkButton.addEventListener('click', insertLink);
+    closeButton.addEventListener('click', () => {
+        document.body.classList.remove('plans-editor-focused');
+        submitButton.focus();
+    });
+    submitButton.addEventListener('focus', () => {
+        document.body.classList.remove('plans-editor-focused');
+    });
 
     textarea.parentElement.prepend(styles);
     textarea.parentElement.prepend(toolbar);
@@ -93,6 +128,14 @@ function initToolbar() {
             }
         }
     });
+
+    textarea.addEventListener('focus', () => {
+        document.body.classList.add('plans-editor-focused');
+        textarea.style.setProperty(
+            '--toolbar-height',
+            `${toolbar.offsetHeight}px`
+        );
+    });
 }
 
 /**
@@ -104,6 +147,9 @@ function initToolbar() {
 function buildaButton(label, icon = false) {
     const button = document.createElement('button');
     button.type = 'button';
+    button.classList.add(
+        `plans-editor-button--${label.toLowerCase().replace(' ', '-')}`
+    );
     if (icon) {
         button.setAttribute('aria-label', label);
         button.innerHTML = icons[icon];

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -148,6 +148,10 @@ function initToolbar() {
                 case 'k':
                     insertLink(e);
                     break;
+                    break;
+                case 'l':
+                    insertPlanLove(e);
+                    break;
             }
         }
     });

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     	PlansEditorToolbar
 // @description	Adds date, hr, bold, italic, and link buttons to the Plans editor for easier formatting (especially on mobile!)
-// @version  	1.4.1
+// @version  	1.5.0-beta
 // @match		https://grinnellplans.com/*
 // @downloadURL https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
 // @updateURL 	https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
@@ -21,23 +21,29 @@ const icons = {
     code: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M12 2l4 4v12H4V2h8zM9 13l-2-2 2-2-1-1-3 3 3 3zm3 1l3-3-3-3-1 1 2 2-2 2z"/></svg>',
     hr: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M4 9h12v2H4V9z"/></svg>',
     date: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M15 4h3v14H2V4h3V3c0-.83.67-1.5 1.5-1.5S8 2.17 8 3v1h4V3c0-.83.67-1.5 1.5-1.5S15 2.17 15 3v1zM6 3v2.5c0 .28.22.5.5.5s.5-.22.5-.5V3c0-.28-.22-.5-.5-.5S6 2.72 6 3zm7 0v2.5c0 .28.22.5.5.5s.5-.22.5-.5V3c0-.28-.22-.5-.5-.5s-.5.22-.5.5zm4 14V8H3v9h14zM7 16V9H5v7h2zm4 0V9H9v7h2zm4 0V9h-2v7h2z"/></svg>',
+    close: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M15.75 6.75L18 3v14l-2.25-3.75L17 12h-4v4l1.25-1.25L18 17H2l3.75-2.25L7 16v-4H3l1.25 1.25L2 17V3l2.25 3.75L3 8h4V4L5.75 5.25 2 3h16l-3.75 2.25L13 4v4h4z"/></svg>',
+    save: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.5 2H3.7C2.7 2 2 2.7 2 3.7v12.6c0 1 .7 1.7 1.7 1.7h12.6c1 0 1.7-.7 1.7-1.7V6l-3.5-4zM10 15.6a2.1 2.1 0 1 1 0-4.2 2.1 2.1 0 0 1 0 4.2zm2.7-7.5H4.3V4.2h8.4v4z"/></svg>',
 };
 const styles = document.createElement('style');
 styles.innerHTML = `
 .plans-editor-toolbar {
     display: flex;
-    gap: 0.5em;
-    margin-block-end: 0.5em;
+    align-items: center;
+    gap: 0.5rem;
+    margin-block-end: 0.5rem;
 }
-.plans-editor-toolbar button {
+.plans-editor-toolbar button,
+.submitinput {
     display: inline-flex;
-    padding: .1875em;
+    align-items: center;
+    padding: .1875rem;
+    gap: .25em;
     line-height: 1;
-    font-family: monospace;
 }
-.plans-editor-toolbar svg {
-    width: 18px;
-    height: 18px;
+.plans-editor-toolbar svg,
+.submitinput svg {
+    width: 20px;
+    height: 20px;
 }
 .plans-editor-button--close-editor {
     display: none !important;
@@ -51,16 +57,24 @@ styles.innerHTML = `
         }
         .plans-editor-toolbar {
             position: fixed;
-            top: 0;
-            left: 0;
+            inset-block-start: 0;
+            inset-inline-start: 0;
             width: 100%;
+            padding: .25rem;
             z-index: 1000000;
             background: currentColor;
-            padding: .25em;
         }
         .plans-editor-button--close-editor {
-            display: block !important;
+            display: inline-flex !important;
             margin-inline-start: auto;
+            margin-inline-end: 0.5rem;
+        }
+        .submitinput {
+            position: absolute;
+            left: 50%;
+            inset-block-end: .25rem;
+            transform: translateX(-50%);
+            z-index: 1000000;
         }
     }
 }
@@ -84,7 +98,7 @@ function initToolbar() {
     const boldButton = buildaButton('Bold', 'bold');
     const italicButton = buildaButton('Italic', 'italic');
     const linkButton = buildaButton('Link', 'link');
-    const closeButton = buildaButton('Close Editor', '');
+    const closeButton = buildaButton('Close Editor', 'close');
 
     toolbar.appendChild(dateButton);
     toolbar.appendChild(hrButton);
@@ -92,6 +106,8 @@ function initToolbar() {
     toolbar.appendChild(italicButton);
     toolbar.appendChild(linkButton);
     toolbar.appendChild(closeButton);
+
+    submitButton.innerHTML = icons.save + submitButton.innerHTML;
 
     dateButton.addEventListener('click', () => {
         insertText('[date]');

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -1,10 +1,8 @@
 // ==UserScript==
 // @name     	PlansEditorToolbar
-// @description	Adds date, hr, bold, italic, and link buttons to the Plans editor for easier formatting (especially on mobile!)
-// @version  	1.5.0-beta3
-// @match		https://grinnellplans.com/*
-// @downloadURL https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
-// @updateURL 	https://github.com/mrwweb/plans-editor-toolbar/raw/master/plans-editor-toolbar.user.js
+// @description	Bold, italic, date, hr, planlove, and link buttons and shortcuts for the Plans editor. Full-screen mode on mobile.
+// @version  	1.5.0
+// @match		https://grinnellplans.com/edit.php
 // @supportURL	https://github.com/mrwweb/plans-editor-toolbar/issues/
 // @source		https://github.com/mrwweb/plans-editor-toolbar/
 // @author		[rootwile] aka Mark Root-Wiley

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -154,6 +154,7 @@ function initToolbar() {
                     insertPlanLove(e);
                     break;
                 case 's':
+                    e.preventDefault();
                     editForm.requestSubmit(submitButton);
                     break;
             }

--- a/plans-editor-toolbar.user.js
+++ b/plans-editor-toolbar.user.js
@@ -21,8 +21,8 @@ const icons = {
     code: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M12 2l4 4v12H4V2h8zM9 13l-2-2 2-2-1-1-3 3 3 3zm3 1l3-3-3-3-1 1 2 2-2 2z"/></svg>',
     hr: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M4 9h12v2H4V9z"/></svg>',
     date: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M15 4h3v14H2V4h3V3c0-.83.67-1.5 1.5-1.5S8 2.17 8 3v1h4V3c0-.83.67-1.5 1.5-1.5S15 2.17 15 3v1zM6 3v2.5c0 .28.22.5.5.5s.5-.22.5-.5V3c0-.28-.22-.5-.5-.5S6 2.72 6 3zm7 0v2.5c0 .28.22.5.5.5s.5-.22.5-.5V3c0-.28-.22-.5-.5-.5s-.5.22-.5.5zm4 14V8H3v9h14zM7 16V9H5v7h2zm4 0V9H9v7h2zm4 0V9h-2v7h2z"/></svg>',
-    close: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M15.75 6.75L18 3v14l-2.25-3.75L17 12h-4v4l1.25-1.25L18 17H2l3.75-2.25L7 16v-4H3l1.25 1.25L2 17V3l2.25 3.75L3 8h4V4L5.75 5.25 2 3h16l-3.75 2.25L13 4v4h4z"/></svg>',
-    save: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.5 2H3.7C2.7 2 2 2.7 2 3.7v12.6c0 1 .7 1.7 1.7 1.7h12.6c1 0 1.7-.7 1.7-1.7V6l-3.5-4zM10 15.6a2.1 2.1 0 1 1 0-4.2 2.1 2.1 0 0 1 0 4.2zm2.7-7.5H4.3V4.2h8.4v4z"/></svg>',
+    close: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M15.75 6.75L18 3v14l-2.25-3.75L17 12h-4v4l1.25-1.25L18 17H2l3.75-2.25L7 16v-4H3l1.25 1.25L2 17V3l2.25 3.75L3 8h4V4L5.75 5.25 2 3h16l-3.75 2.25L13 4v4h4z"/></svg>',
+    save: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M14.5 2H3.7C2.7 2 2 2.7 2 3.7v12.6c0 1 .7 1.7 1.7 1.7h12.6c1 0 1.7-.7 1.7-1.7V6l-3.5-4zM10 15.6a2.1 2.1 0 1 1 0-4.2 2.1 2.1 0 0 1 0 4.2zm2.7-7.5H4.3V4.2h8.4v4z"/></svg>',
 };
 const styles = document.createElement('style');
 styles.innerHTML = `
@@ -33,7 +33,7 @@ styles.innerHTML = `
     margin-block-end: 0.5rem;
 }
 .plans-editor-toolbar button,
-.submitinput {
+#editbox .submitinput {
     display: inline-flex;
     align-items: center;
     padding: .1875rem;
@@ -41,7 +41,7 @@ styles.innerHTML = `
     line-height: 1;
 }
 .plans-editor-toolbar svg,
-.submitinput svg {
+#editbox .submitinput svg {
     width: 20px;
     height: 20px;
 }
@@ -52,6 +52,8 @@ styles.innerHTML = `
     .plans-editor-focused {
         textarea {
             position: fixed;
+            width: 100%;
+            height: 100%;
             inset: var(--toolbar-height) 0 0 0;
             z-index: 999999;
         }
@@ -69,7 +71,7 @@ styles.innerHTML = `
             margin-inline-start: auto;
             margin-inline-end: 0.5rem;
         }
-        .submitinput {
+        #editbox .submitinput {
             position: absolute;
             left: 50%;
             inset-block-end: .25rem;
@@ -80,7 +82,7 @@ styles.innerHTML = `
 }
 `;
 
-const submitButton = document.querySelector('button.submitinput');
+const submitButton = document.querySelector('#editbox .submitinput');
 const textarea = document.getElementsByTagName('textarea')[0];
 if (textarea !== undefined) {
     initToolbar();

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Plans Editor Toolbar
 
-v1.4.1 ([Changelog](#changelog))
+v1.5.0 ([Changelog](#changelog))
 
 [GrinnellPlans](https://grinnellplans.com) can be a little easier to use—especialy for new users or those without physical keyboards—with a simple toolbar for formatting text.
 
@@ -39,6 +39,11 @@ All browsers can use the Tampermonkey browser extension, a cross-browser success
 - Undo / Redo doesn't work for toolbar actions. It could be added if enough people run into problems.
 
 ## Changelog
+
+### v1.5.0-beta (February 22, 2024)
+
+- Editor now switches to full screen mode when editing on phones
+- "Change Plan" aka save button gets a fun disk icon
 
 ### v1.4.1 (February 21, 2024)
 
@@ -79,6 +84,7 @@ Mark Root-Wiley ([rootwile])
 
 - [GrinnellPlans Source on Github](https://github.com/grinnellplans/)
 - Editor icons from [Dashicons](https://github.com/WordPress/dashicons/)
+- [Save icon](https://thenounproject.com/icon/save-1050704/) from Noun Project (purchased with license)
 
 ## Other Plans Stuff
 

--- a/readme.md
+++ b/readme.md
@@ -4,13 +4,29 @@ v1.5.0 ([Changelog](#changelog))
 
 [GrinnellPlans](https://grinnellplans.com) can be a little easier to use—especialy for new users or those without physical keyboards—with a simple toolbar for formatting text.
 
+## Features
+
 This script adds a toolbar with the following features:
 
-- Insert the [date] shortcode
-- Insert the `<hr>` tag to make a horizontal rule
 - Wrap selected text in bold or italic
-- Insert the link syntax `[|]` - OR - wrap selected text inside a link, e.g. `[|{text selection}]`
-- Keyboard shortcuts for bold, italic, and insert link
+- Insert the link syntax `[|]` / wrap selected text inside a link, e.g. `[|{text selection}]`
+- Insert planlove brackets `[]` / wrap selected text inside planlove brackets, e.g. `[{text selection}]`
+- Insert the `[date]` shortcode
+- Insert the `<hr>` tag to make a horizontal rule
+- Keyboard shortcuts!
+- Full screen editor on mobile for _astoundingly_ better usability
+
+### Shorcuts
+
+All shortcuts only work when the editor is in focus. (Should we add shortcuts for `[date]` and `<hr>`?)
+
+| Shortcut      | Action                |
+|-------------- |---------------------- |
+| `Ctrl` + `b`  | Bold                  |
+| `Ctrl` + `i`  | Italic                |
+| `Ctrl` + `k`  | Make/Insert link      |
+| `Ctrl` + `l`  | Make/Insert planlove  |
+| `Ctrl` + `s`  | Save plan             |
 
 ## Installation
 
@@ -40,12 +56,14 @@ All browsers can use the Tampermonkey browser extension, a cross-browser success
 
 ## Changelog
 
-### v1.5.0-beta3 (February 25, 2024)
+### v1.5.0 (February 28, 2024)
 
 - New Editor fullscreen mode when editing on phones! (Added close button when editor is in fullscreen mode)
 - New button to insert planlove brackets (e.g., "[]")
+- `Ctrl` + `s` will now save your plan
 - Reordered toolbar buttons to put formatting buttons first
 - "Change Plan" button aka save button gets a fun disk icon
+- Roll back previous change that tried to target all editors. Only apply to the main Plan text editor for now (not notes, secrets)
 
 ### v1.4.1 (February 21, 2024)
 

--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,12 @@ All browsers can use the Tampermonkey browser extension, a cross-browser success
 
 ## Changelog
 
-### v1.5.0-beta (February 22, 2024)
+### v1.5.0-beta3 (February 25, 2024)
 
-- Editor now switches to full screen mode when editing on phones
-- "Change Plan" aka save button gets a fun disk icon
+- New Editor fullscreen mode when editing on phones! (Added close button when editor is in fullscreen mode)
+- New button to insert planlove brackets (e.g., "[]")
+- Reordered toolbar buttons to put formatting buttons first
+- "Change Plan" button aka save button gets a fun disk icon
 
 ### v1.4.1 (February 21, 2024)
 


### PR DESCRIPTION
### v1.5.0 (February 28, 2024)

- New Editor fullscreen mode when editing on phones! (Added close button when editor is in fullscreen mode). Closes #8 
- New button to insert planlove brackets (e.g., "[]"). Closes #18 
- `Ctrl` + `s` will now save your plan. Closes #17 
- Reordered toolbar buttons to put formatting buttons first
- "Change Plan" button aka save button gets a fun disk icon
- Roll back previous change that tried to target all editors. Only apply to the main Plan text editor for now (not notes, secrets)